### PR TITLE
add common greenhouse gases as individual base units

### DIFF
--- a/checks.csv
+++ b/checks.csv
@@ -11,3 +11,4 @@ toe,  [energy],
 tce,  [energy], *
 GW a, [energy],
 kWa,  [energy], *
+EUR_2005, [currency], *

--- a/checks.csv
+++ b/checks.csv
@@ -12,3 +12,5 @@ tce,  [energy], *
 GW a, [energy],
 kWa,  [energy], *
 EUR_2005, [currency], *
+CO2,    [carbon_dioxide], *
+nh3,  [ammonia], *

--- a/definitions.txt
+++ b/definitions.txt
@@ -47,7 +47,10 @@ tkm = tonne_freight * kilometer
 # changed between IPCC reports and their values depend on the assumed timespan.
 
 carbon_dioxide = [carbon_dioxide] = co2 = CO2
-# molecular weight of carbon dioxide to that of carbon: 44/12
+
+# in the context of emissions, concentrations and resulting radiative forcing,
+# carbon and carbon dioxide are usually treated as equivalent 
+# multiplied by the molecular weight of carbon dioxide relative to carbon
 carbon = 44/12 * co2 = C
 
 carbon_monoxide = [carbon_monoxide] = co = CO

--- a/definitions.txt
+++ b/definitions.txt
@@ -38,3 +38,26 @@ tkm = tonne_freight * kilometer
 @alias vkm = vkt = v km
 @alias pkm = pkt = p km
 @alias tkm = tkt = t km
+
+
+# Emissions of various greenhouse gases
+
+# DO NOT ADD carbon-dioxide-equivalent conversion factors in this file!
+# 'Global warming potential (GWP)' factors to convert to CO2-equivalents
+# changed between IPCC reports and their values depend on the assumed timespan.
+
+carbon_dioxide = [carbon_dioxide] = co2 = CO2
+# molecular weight of carbon dioxide to that of carbon: 44/12
+carbon = 44/12 * co2 = C
+
+carbon_monoxide = [carbon_monoxide] = co = CO
+
+methane = [methane] = ch4 = CH4
+
+nitrous_oxide = [nitrous_oxide] = n2o = N2O
+
+nitrogen_oxides = [nitrogen_oxides] = nox = NOx
+
+ammonia = [ammonia] = nh3 = NH3
+
+sulfur = [sulfur] = S

--- a/definitions.txt
+++ b/definitions.txt
@@ -48,11 +48,6 @@ tkm = tonne_freight * kilometer
 
 carbon_dioxide = [carbon_dioxide] = co2 = CO2
 
-# in the context of emissions, concentrations and resulting radiative forcing,
-# carbon and carbon dioxide are usually treated as equivalent 
-# multiplied by the molecular weight of carbon dioxide relative to carbon
-carbon = 44/12 * co2 = C
-
 carbon_monoxide = [carbon_monoxide] = co = CO
 
 methane = [methane] = ch4 = CH4

--- a/test.py
+++ b/test.py
@@ -24,7 +24,7 @@ with open(Path(__file__).with_name('checks.csv')) as f:
 
         # Convert second column to a dimensionality object
         dims = {dims: 1} if dims.startswith('[') else eval(dims)
-        dims = defaults.get_dimensionality(UnitsContainer(dims))
+        dims = UnitsContainer(dims)
 
         # Convert third column to boolean
         new_def = len(new_def) > 0
@@ -48,6 +48,9 @@ def test_units(registry, unit_str, dim, new_def):
         # Units defined in dimensions.txt are not recognized by base pint
         with pytest.raises(pint.UndefinedUnitError):
             defaults('1 ' + unit_str)
+
+    # Physical quantity of units is recognized
+    dim = registry.get_dimensionality(dim)
 
     # Units can be parsed and have the correct dimensionality
     assert registry('1 ' + unit_str).dimensionality == dim


### PR DESCRIPTION
This PR adds the most common greenhouse gases as individual base units. It also adds a warning to the definitions-file not to add CO2-equivalents here - this should wait for a cleaner solution to use pint-contexts or a clear reference to the IPCC report and the GWP-x.

PS: I tried to have both carbon and carbon dioxide as base units like
```
carbon_dioxide = [carbon_dioxide] = co2 = CO2
carbon = [carbon] = C=
# molecular weight of carbon dioxide to that of carbon: 44/12
[carbon] = 44/12 * [carbon_dioxide]
```
but pint seems to ignore the factor in the dimensions-conversion...

