### PR TITLE
Overwrite `kt` as kilotons rather than `knot [velocity]`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,9 @@ Warnings
    - - 'C' = Coulomb
      - 'C' = carbon
      - See `emissions.txt`_ at line 10.
+   - - 'kt' = knot [velocity]
+     - 'kt' = 1000 metric tons
+     - 'kt' is commonly used for emissions in the IAM-context.
 
 Technical details
 =================

--- a/iam_units/data/definitions.txt
+++ b/iam_units/data/definitions.txt
@@ -8,6 +8,11 @@
 
 tonne_of_coal_equivalent = 29.308 GJ = tce
 
+# Fix for pint interpreting `kt` as knot [velocity] rather than kilo-ton
+# (see https://github.com/IAMconsortium/units/issues/13
+
+kt = 1e6 * kilogram
+
 # Watt-annum
 Wa = watt * year
 
@@ -54,7 +59,6 @@ tkm = tonne_freight * kilometer
 @alias vkm = vkt = v km
 @alias pkm = pkt = p km
 @alias tkm = tkt = t km
-
 
 # Emissions of various greenhouse gases
 

--- a/iam_units/test_all.py
+++ b/iam_units/test_all.py
@@ -55,7 +55,7 @@ def test_orders_of_magnitude():
     assert registry('1.2 billion EUR').to('million EUR').magnitude == 1.2e3
 
 
-def test_kt_13():
+def test_kt():
     # The registry should correctly interpret `kt` as a weight (not velocity)
     assert str(registry('1000 kt').to('Mt')) == '1.0 megametric_ton'
 

--- a/iam_units/test_all.py
+++ b/iam_units/test_all.py
@@ -55,6 +55,15 @@ def test_orders_of_magnitude():
     assert registry('1.2 billion EUR').to('million EUR').magnitude == 1.2e3
 
 
+def test_kt_13():
+    # The registry should correctly interpret `kt` as a weight (not velocity)
+    assert str(registry('1000 kt').to('Mt')) == '1.0 megametric_ton'
+
+    # A default UnitRegistry should interpret `kt` as velocity
+    with pytest.raises(pint.DimensionalityError):
+        pint.UnitRegistry()('kt').to('Mt')
+
+
 @pytest.mark.parametrize('context, value',
                          [('AR5GWP100', 28),
                           ('AR4GWP100', 25),


### PR DESCRIPTION
This PR adds an overwrite to `definitions.txt` that `kt` is interpreted as kilotons rather than knot (velocity). This simplifies working with emissions, which are typically measured as weights.

closes #13