### PR TITLE
Define orders of magnitude to be used as prefix

### DIFF
--- a/iam_units/data/definitions.txt
+++ b/iam_units/data/definitions.txt
@@ -12,6 +12,17 @@ tonne_of_coal_equivalent = 29.308 GJ = tce
 Wa = watt * year
 
 
+# Orders of magnitude (short scale) to be used as prefix for other units
+# https://en.wikipedia.org/wiki/Order_of_magnitude
+
+hundred = 1e2
+thousand = 1e3
+million = 1e6
+billion = 1e9
+trillion = 1e12
+quadrillion = 1e15
+
+
 # Currency
 
 # Based on Germany's GDP deflator, data from

--- a/iam_units/test_all.py
+++ b/iam_units/test_all.py
@@ -50,9 +50,9 @@ def test_units(unit_str, dim, new_def):
     assert registry('1 ' + unit_str).dimensionality == dim
 
 
-def test_orders_of_magnitude_14():
+def test_orders_of_magnitude():
     # The registry recognizes units prefixed by an order of magnitude
-    assert registry('billion EUR').to('million EUR').magnitude == 1e3
+    assert registry('1.2 billion EUR').to('million EUR').magnitude == 1.2e3
 
 
 @pytest.mark.parametrize('context, value',

--- a/iam_units/test_all.py
+++ b/iam_units/test_all.py
@@ -50,6 +50,11 @@ def test_units(unit_str, dim, new_def):
     assert registry('1 ' + unit_str).dimensionality == dim
 
 
+def test_orders_of_magnitude_14():
+    # The registry recognizes units prefixed by an order of magnitude
+    assert registry('billion EUR').to('million EUR').magnitude == 1e3
+
+
 @pytest.mark.parametrize('context, value',
                          [('AR5GWP100', 28),
                           ('AR4GWP100', 25),


### PR DESCRIPTION
This PR adds common spelled-out orders of magnitude (million, billion) to the definitions.

closes #14 