### PR TITLE
Add litre gasoline-equivalent conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 
 # Editors
 .idea/*
+*.eggs

--- a/iam_units/data/definitions.txt
+++ b/iam_units/data/definitions.txt
@@ -63,5 +63,6 @@ tkm = tonne_freight * kilometer
 # Emissions of various greenhouse gases
 @import emissions/emissions.txt
 
-# Litres of gasoline-equivalent
+# Litres of gasoline-equivalent. Conversion values from
+# https://theicct.org/sites/default/files/publications/GFEI_WP19_Final_V3_Web.pdf, page 24, footnote 23.
 Lge = 33.5 * MJ

--- a/iam_units/data/definitions.txt
+++ b/iam_units/data/definitions.txt
@@ -62,3 +62,6 @@ tkm = tonne_freight * kilometer
 
 # Emissions of various greenhouse gases
 @import emissions/emissions.txt
+
+# Litres of gasoline-equivalent
+Lge = 33.5 * MJ


### PR DESCRIPTION
This PR addresses the addition of the energy unit conversion of `litres of gasoline-equivalent` (`Lge`). These units are used to represent quantities in [this GFEI report](https://theicct.org/sites/default/files/publications/GFEI_WP19_Final_V3_Web.pdf), from which we happened to received some data.

How to review:
- Check that the following commands work in your own machine:
```
from iam_units import registry
qty = registry('33.5 MJ')
qty.to('Lge')
1.0 <Unit('Lge')>
```