### PR TITLE
Allow conversions between C and CO2 without GWP-context

### DIFF
--- a/iam_units/data/emissions/emissions.txt
+++ b/iam_units/data/emissions/emissions.txt
@@ -7,10 +7,6 @@ _gwp = [_GWP]
 
 a_CO2 = 1.0
 
-# Conversion to/from carbon equivalent is the same regardless of metric.
-
-a_C = 44. / 12
-
 # Define:
 # - Equivalents, e.g. a_CO2e = a_CO2.
 # - Conversion factors for each species, with NaN values. pint requires

--- a/iam_units/data/emissions/species.txt
+++ b/iam_units/data/emissions/species.txt
@@ -5,7 +5,8 @@
 a_CO2_eq = a_CO2
 a_CO2e = a_CO2
 a_CO2eq = a_CO2
-a_Ce = a_C
+a_C = 44. / 12 * a_CO2
+a_Ce = 44. / 12 * a_CO2
 a_C10F18 = NaN
 a_C2F6 = NaN
 a_C3F8 = NaN

--- a/iam_units/emissions.py
+++ b/iam_units/emissions.py
@@ -98,7 +98,7 @@ SPECIES = [
     "cC4F8",
 ]
 
-# Pairs of emission species symbols that are interchangeable.
+# Sets of symbols that refer to the same species and are interchangeable.
 EQUIV = [
     set(["CO2", "CO2_eq", "CO2e", "CO2eq", "C", "Ce"]),
 ]

--- a/iam_units/emissions.py
+++ b/iam_units/emissions.py
@@ -100,8 +100,7 @@ SPECIES = [
 
 # Pairs of emission species symbols that are interchangeable.
 EQUIV = [
-    set(["CO2", "CO2_eq", "CO2e", "CO2eq"]),
-    set(["C", "Ce"]),
+    set(["CO2", "CO2_eq", "CO2e", "CO2eq", "C", "Ce"]),
 ]
 
 # Regular expression for one *SPECIES* in a pint-compatible unit string.

--- a/iam_units/test_all.py
+++ b/iam_units/test_all.py
@@ -114,17 +114,21 @@ def test_convert_gwp(units, metric, species_in, species_out, expected_value):
     assert_array_almost_equal(result.magnitude, expected)
 
 
-def test_convert_gwp_carbon():
+@pytest.mark.parametrize(
+    "context",
+    ["AR5GWP100", None],
+)
+def test_convert_gwp_carbon(context):
     # CO2 can be converted to C
     qty = (44.0 / 12, "tonne CO2")
-    result = convert_gwp("AR5GWP100", qty, "C")
+    result = convert_gwp(context, qty, "C")
     assert result.units == registry("tonne")
     assert_almost_equal(result.magnitude, 1.0)
 
     # C can be converted to CO2
     qty = (1, "tonne C")
     expected = registry.Quantity(44.0 / 12, "tonne")
-    assert convert_gwp("AR5GWP100", qty, "CO2e") == expected
+    assert convert_gwp(context, qty, "CO2e") == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
While preparing some work for AR6 WG1, I ran into #23 again - not being able to convert C and CO2 without specifying a GWP-context, even though this is just by definition a multiplicative factor.

This PR defines C as an alias of CO2 and updates the equivalence-mapping. The corresponding test is extended to also test that conversion works if no context is provided.

FYI, I also tested that this works in pyam without any changes in the pyam codebase.
The following works with the changes proposed in this PR:
```python
df.convert_unit("Pg C", "Gt CO2")
```

closes #23