### PR TITLE
Adjust for pint 0.18

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        pint-version:
+        # Force specific version of pint
+        - "==0.17"
+        - "==0.18"
+        # No change, i.e. latest
+        - ""
+
+    name: pint${{ matrix.pint-version }}
+
     steps:
     - uses: actions/checkout@v2
 
@@ -21,6 +33,7 @@ jobs:
       run: |
         pip install numpy pytest pytest-cov setuptools-scm
         pip install --editable .
+        pip install pint${{ matrix.pint-version }}
         pytest -rA --verbose --color=yes --cov=iam_units --cov-report=xml
 
     - name: Upload test coverage to Codecov.io


### PR DESCRIPTION
- One-line change to adjust to changes in `pint.formatting.format_units()` from pint 0.17 to 0.18.
- Matrix the GitHub Actions workflow to test these versions of pint, plus the latest version.

Supersedes #32
Closes #31