### PR TITLE
Adjust to pint 0.19

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,7 @@ jobs:
         twine check dist/*
 
     - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.5.0
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       with:
         user: __token__
@@ -40,7 +40,7 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.5.0
       if: github.event_name == 'release'
       with:
         user: __token__

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         # Force specific version of pint
         - "==0.17"
         - "==0.18"
-        - "==0.19"
+        - "==0.19.1"
         # No change, i.e. latest
         - ""
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,7 @@ jobs:
         # Force specific version of pint
         - "==0.17"
         - "==0.18"
+        - "==0.19"
         # No change, i.e. latest
         - ""
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
 
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
@@ -40,4 +40,4 @@ jobs:
         pytest -rA --verbose --color=yes --cov=iam_units --cov-report=xml
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v1.2.1
+      uses: codecov/codecov-action@v2

--- a/iam_units/update.py
+++ b/iam_units/update.py
@@ -43,7 +43,7 @@ _EMI_DATA = f"""{_EMI_HEADER}
 # - Preceded by a space or '-' character.
 # - Followed by a space, '-', '/', end-of-string, or non-word (\w) character.
 #   The latter avoids matching only the 'C' within 'CH4'.
-_EMI_CODE = fr"""{_EMI_HEADER}
+_EMI_CODE = rf"""{_EMI_HEADER}
 import re
 
 GWP_VERSION = '{gwp.__version__}'

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,18 @@ description = Unit definitions for integrated-assessment research
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 url = https://github.com/IAMconsortium/units
+classifiers =
+    Intended Audience :: Developers
+    Intended Audience :: Science/Research
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Information Analysis
 
 [options]
 packages = iam_units


### PR DESCRIPTION
Pint 0.19 was released about 2 hours ago; failures are visible, e.g. [here](https://github.com/IAMconsortium/units/runs/5819737771?check_suite_focus=true#step:5:75) or [here](https://github.com/khaeru/genno/runs/5817947877?check_suite_focus=true#step:10:115). This turns out to be a regression; see hgrecco/pint#1498.

This PR is to implement and check a workaround or fix, depending on the response upstream.