### PR TITLE
Add typing_extensions to py3.7 deps for Literal

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
+        python-version: "3.x"
         cache: pip
         cache-dependency-path: "**/pyproject.toml"
 

--- a/iam_units/currency.py
+++ b/iam_units/currency.py
@@ -3,7 +3,13 @@
 See the inline comments (NB) for possible extensions of this code; also
 iam_units.update.currency.
 """
-from typing import Literal, Union
+from typing import Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal  # type: ignore [assignment]
+
 
 #: Exchange rate data for method=EXC, period=2005, from
 #: https://data.oecd.org/conversion/exchange-rates.htm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Information Analysis",
 ]
-dependencies = ["pint >= 0.11"]
+dependencies = ["pint >= 0.11", "typing_extensions; python_version < '3.8'"]
 
 [project.urls]
 homepage = "https://github.com/IAMconsortium/units"


### PR DESCRIPTION
#44 added use of Literal, which is only available in Python ≥3.8. This raises ImportError, for instance [here](https://github.com/iiasa/ixmp/actions/runs/6155105076/job/16703073074):
```
__________ ERROR collecting ixmp/tests/reporting/test_computations.py __________
ImportError while importing test module '/home/runner/work/ixmp/ixmp/ixmp/tests/reporting/test_computations.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ixmp/tests/reporting/test_computations.py:6: in <module>
    import pyam
/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pyam/__init__.py:12: in <module>
    from pyam.core import *
/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pyam/core.py:59: in <module>
    from pyam._ops import _op_data
/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pyam/_ops.py:5: in <module>
    from iam_units import registry
/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/iam_units/__init__.py:9: in <module>
    from .currency import configure_currency
/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/iam_units/currency.py:6: in <module>
    from typing import Literal, Union
E   ImportError: cannot import name 'Literal' from 'typing' (/opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/typing.py)
```

This commit imports the same from typing_extensions for Python 3.7.

Note that Python 3.7 reached EOL as of 2023-06-06, and we should probably drop support for it soon. This preserves support in the interim.