### PR TITLE
Bridge USD and EUR across all vintages at a chosen exchange-rate period

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -91,3 +91,16 @@ The current generator uses OECD Table 4 via ``sdmx1``. ``EUR`` rows are derived 
 ``DEU`` series in that table: this is exact for exchange-rate methods because Germany's
 national currency is EUR, but it is a substantive modeling choice for PPP methods and
 should remain explicit in code and documentation.
+
+Extending the supported periods or currencies also requires manual edits to
+``iam_units/data/definitions.txt``, which is not generated:
+
+- Every period listed in ``update._CURRENCY_PERIODS`` needs a matching
+  ``_{currency}_deflator_{period}`` factor. ``configure_currency()`` refers to these by
+  name when it defines the bridge. pint resolves a definition lazily, so a missing
+  factor is accepted there and raises ``UndefinedUnitError`` at the first conversion.
+- Every currency needs a chain anchor ``{currency}_2005``, against which its other
+  vintages and the bridge are defined.
+
+``test_currency_bridge`` covers each period with a pinned expected magnitude; expand it
+when adding one.

--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ Currency
 
 ``iam_units`` defines deflators for:
 
-- USD (United States dollar) for annual periods from 2000 to 2022 inclusive.
+- USD (United States dollar) for annual periods from 2000 to 2024 inclusive.
 - EUR (Euro) for the periods 2005, 2010, 2015, 2020, and 2024 only.
 
 These can be used via pint-compatible unit expressions like ``USD_2019``
@@ -191,15 +191,29 @@ To enable conversions between *different* currencies, use the function ``configu
    >>> qty.to("EUR_2005")
    26.022132012144635 <Unit('EUR_2005')>
 
-Calling ``configure_currency()`` again with the same method and currency/period pair on
-the same registry is a no-op. Calling it with a different method for an already
-configured pair raises ``ValueError`` rather than silently reusing the first definition.
+``period`` selects the year of the USD↔EUR exchange rate used to *bridge* the two
+currencies — not the target vintage. The within-currency deflator chains then carry any
+``USD_*`` vintage to any defined ``EUR_*`` vintage; because the currencies do not
+inflate in lock-step, different ``period`` values give different results:
+
+.. code-block:: python
+
+   # On a fresh registry — bridge at the 2010 exchange rate instead
+   >>> configure_currency(method="EXC", period="2010")
+
+   >>> registry("100 USD_2010").to("EUR_2024")
+   104.940225 <Unit('EUR_2024')>
+
+A registry holds one bridge per target currency: repeated calls with the same ``method``
+and ``period`` are a no-op, and changing either raises ``ValueError``. ``period=2005``
+gives the same results as previous versions.
 
 Currently ``iam_units`` supports:
 
 - annual OECD Table 4 exchange-rate / PPP methods ``EXC``, ``EXCE``, ``PPPGDP``,
   ``PPPPRC``, and ``PPPP41``;
-- EUR for the periods 2005, 2010, 2015, 2020, and 2024; and
+- any ``period`` that is both an OECD exchange-rate year and a defined EUR deflator
+  vintage: 2005, 2010, 2015, 2020, and 2024; and
 - USD as the base currency for those conversions.
 
 Up to v2025.9.12, ``configure_currency("EXC", 2005)`` was called automatically.

--- a/iam_units/currency.py
+++ b/iam_units/currency.py
@@ -8,7 +8,7 @@ from .currency_data import DATA
 if TYPE_CHECKING:
     from pint import UnitRegistry
 
-CONFIGURED_CURRENCY_ATTR = "_iam_units_configured_currency_methods"
+CONFIGURED_CURRENCY_ATTR = "_iam_units_configured_currency_bridges"
 
 
 class METHOD(Enum):
@@ -43,20 +43,28 @@ def configure_currency(
     method : METHOD or str
         Method of computing exchange rate data.
     period : int or str
-        Time period (e.g. year) for exchange rates.
+        Year of the USD↔currency exchange rate used to bridge the two currencies.
 
     Notes
     -----
-    Currency units can only be configured once per ``(currency, period)`` pair and
-    method on a given registry. Repeated calls with the same method are a no-op; a
-    different method raises an exception for any already-configured pairs.
+    `period` selects only the exchange-rate bridge year; the within-currency deflator
+    chains then carry any USD vintage to any defined target vintage. For example,
+    ``configure_currency("EXC", 2010)`` converts between any ``USD_*`` and any ``EUR_*``
+    using the 2010 EUR/USD exchange rate as the bridge. Because the currencies do not
+    inflate in lock-step, different `period` values give different results.
+
+    A registry holds one bridge per target currency. Repeated calls with the same
+    `method` and `period` are a no-op; a call that changes either for an
+    already-configured currency raises, rather than silently altering earlier
+    conversions.
 
     Raises
     ------
     NotImplementedError
         For unsupported values of `method` or `period`.
     ValueError
-        For repeated calls with different `method`.
+        For an unknown `method`, or a call that changes the configured `method` or
+        `period` for an already-bridged currency.
     """
     if _registry is None:
         from iam_units import registry
@@ -73,35 +81,50 @@ def configure_currency(
     period = str(period)
 
     try:
-        data = DATA[method.name, period].copy()
+        data = DATA[method.name, period]
     except KeyError:
         raise NotImplementedError(
             f"Convert currency for method={method!r}, period={period}; use one of:\n"
             + repr(sorted(DATA))
         )
 
-    # Maybe retrieve a dict mapping from (other, period): method for every already-
-    # configured currency
-    configured = dict(getattr(registry, CONFIGURED_CURRENCY_ATTR, {}))
+    # One bridge per target currency: map each currency to its active (method, period)
+    bridge = (method, period)
+    configured: dict[str, tuple[METHOD, str]] = dict(
+        getattr(registry, CONFIGURED_CURRENCY_ATTR, {})
+    )
 
-    # Identify any conflicting, existing configurations: keys appearing in both `data`
-    # and `configured` with different methods
+    # Identify any conflicting, existing configurations: currencies already bridged
+    # with a different method or period
     if conflicts := {
-        k: m for k, m in configured.items() if k in data and m is not method
+        other: existing
+        for other, _ in data
+        if (existing := configured.get(other)) is not None and existing != bridge
     }:
-        unit_list = sorted(
-            (f"{other}_{period} (configured with method={method_configured.name!r})")
-            for (other, period), method_configured in conflicts.items()
+        detail = ", ".join(
+            f"{other} (configured with method={m.name!r}, period={p})"
+            for other, (m, p) in sorted(conflicts.items())
         )
         raise ValueError(
-            f"configure_currency() cannot change to method={method.name!r} for already "
-            f"defined units: {', '.join(unit_list)}"
+            f"configure_currency() cannot change to method={method.name!r}, "
+            f"period={period} for already configured: {detail}"
         )
 
-    # Insert definitions
-    for (other, period), value in data.items():
-        registry.define(f"{other}_{period} = USD_{period} / {value} = {other}")
-        configured[(other, period)] = method
+    # Anchor the bridge at each target currency's chain base ({other}_2005): dividing
+    # the exchange rate by _{other}_deflator_{period} (defined alongside the vintages in
+    # definitions.txt) keeps the whole {other} vintage chain connected to USD through
+    # the chosen bridge year.
+    pending = {
+        other: rate
+        for (other, _), rate in data.items()
+        if configured.get(other) != bridge
+    }
+    for other, rate in pending.items():
+        registry.define(
+            f"{other}_2005 = USD_{period} / {rate} / _{other}_deflator_{period}"
+            f" = {other}"
+        )
+        configured[other] = bridge
 
-    # Store information about configuration
-    setattr(registry, CONFIGURED_CURRENCY_ATTR, configured)
+    if pending:
+        setattr(registry, CONFIGURED_CURRENCY_ATTR, configured)

--- a/iam_units/data/definitions.txt
+++ b/iam_units/data/definitions.txt
@@ -50,14 +50,26 @@ USD_2005 = [currency] = USD
 # https://data.worldbank.org/indicator/NY.GDP.DEFL.KD.ZG?locations=XC
 # Factor calculated by taking the product of annual values in %, so for 
 # example EUR_2007 = (1 - (V_2007/100)) * (1 - (V_2006/100)) * EUR_2005 
+#
+# The factors are named so that configure_currency() can refer to them: an
+# exchange rate for year Y is quoted against EUR_Y, so bridging it to EUR_2005
+# divides by the factor for Y. They are not currency units and should not be
+# used on their own.
 # last update: 2026-06-02
 
+_EUR_deflator_2000 = 1.166531
+_EUR_deflator_2005 = 1.0
+_EUR_deflator_2010 = 0.901141
+_EUR_deflator_2015 = 0.846094
+_EUR_deflator_2020 = 0.785147
+_EUR_deflator_2024 = 0.647739
+
 EUR_2005 = [currency_EUR] = EUR
-EUR_2000 = 1.166531 * EUR_2005
-EUR_2010 = 0.901141 * EUR_2005
-EUR_2015 = 0.846094 * EUR_2005
-EUR_2020 = 0.785147 * EUR_2005
-EUR_2024 = 0.647739 * EUR_2005
+EUR_2000 = _EUR_deflator_2000 * EUR_2005
+EUR_2010 = _EUR_deflator_2010 * EUR_2005
+EUR_2015 = _EUR_deflator_2015 * EUR_2005
+EUR_2020 = _EUR_deflator_2020 * EUR_2005
+EUR_2024 = _EUR_deflator_2024 * EUR_2005
 
 # United States' GDP deflator, data from
 # https://data.worldbank.org/indicator/NY.GDP.DEFL.ZS?locations=US

--- a/iam_units/data/definitions.txt
+++ b/iam_units/data/definitions.txt
@@ -50,17 +50,18 @@ USD_2005 = [currency] = USD
 # https://data.worldbank.org/indicator/NY.GDP.DEFL.KD.ZG?locations=XC
 # Factor calculated by taking the product of annual values in %, so for 
 # example EUR_2007 = (1 - (V_2007/100)) * (1 - (V_2006/100)) * EUR_2005 
-# last update: 2026-03-10
+# last update: 2026-06-02
 
 EUR_2005 = [currency_EUR] = EUR
 EUR_2000 = 1.166531 * EUR_2005
 EUR_2010 = 0.901141 * EUR_2005
+EUR_2015 = 0.846094 * EUR_2005
 EUR_2020 = 0.785147 * EUR_2005
 EUR_2024 = 0.647739 * EUR_2005
 
 # United States' GDP deflator, data from
 # https://data.worldbank.org/indicator/NY.GDP.DEFL.ZS?locations=US
-# last update: 2023-06-29
+# last update: 2026-08-14
 
 USD_2015 = USD_2005 * 0.8358
 
@@ -87,6 +88,8 @@ USD_2019 = USD_2015 / 1.0729
 USD_2020 = USD_2015 / 1.0869
 USD_2021 = USD_2015 / 1.1357
 USD_2022 = USD_2015 / 1.2152
+USD_2023 = USD_2015 / 1.2577
+USD_2024 = USD_2015 / 1.2889
 
 # Transportation activity
 

--- a/iam_units/test_all.py
+++ b/iam_units/test_all.py
@@ -118,20 +118,60 @@ def test_currency_pppgdp_data_file(local_registry: pint.UnitRegistry) -> None:
     assert converted.magnitude == pytest.approx(28.25337281882418)
 
 
-def test_currency_rejects_redefinition_with_different_method(
+# Parameters for test_currency_bridge(), tuple of:
+# 1. `period` argument to configure_currency().
+# 2. A literal string to be parsed as a quantity.
+# 3. Target units.
+# 4. Expected magnitude of the conversion.
+# Every period in currency_data.DATA and every EUR vintage appears at least once.
+@pytest.mark.parametrize(
+    "period, expr, target, expected",
+    (
+        (2010, "100 USD_2010", "EUR_2024", 104.94022539464198),
+        (2015, "100 USD_2022", "EUR_2000", 53.795012609053),
+        (2020, "100 USD_2005", "EUR_2015", 105.65223993909703),
+        (2024, "100 USD_2024", "EUR_2010", 66.40909521484429),
+        (2005, "100 USD_2019", "EUR_2020", 79.75173644050624),
+        # Reverse direction
+        (2010, "100 EUR_2005", "USD_2015", 160.15168774272087),
+    ),
+)
+def test_currency_bridge(
     local_registry: pint.UnitRegistry,
+    period: int,
+    expr: str,
+    target: str,
+    expected: float,
+) -> None:
+    # Any USD vintage reaches any EUR vintage: across the bridge at `period`'s exchange
+    # rate, then along the EUR deflator chain.
+    configure_currency("EXC", period, _registry=local_registry)
+
+    assert local_registry(expr).to(target).magnitude == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "method, period",
+    (
+        ("EXC", 2024),  # Same method, different period
+        ("PPPGDP", 2005),  # Different method, same period
+    ),
+)
+def test_currency_rejects_redefinition(
+    local_registry: pint.UnitRegistry, method: str, period: int
 ) -> None:
     configure_currency("EXC", 2005, _registry=local_registry)
 
     with pytest.raises(
         ValueError,
         match=(
-            "cannot change to method='PPPGDP' for already defined units: EUR_2005 "
-            r"\(configured with method='EXC'\)"
+            f"cannot change to method='{method}', period={period} for already "
+            r"configured: EUR \(configured with method='EXC', period=2005\)"
         ),
     ):
-        configure_currency("PPPGDP", 2005, _registry=local_registry)
+        configure_currency(method, period, _registry=local_registry)
 
+    # The original bridge is intact after the rejected switch
     converted = local_registry("42.1 USD_2020").to("EUR_2005")
     assert converted.magnitude == pytest.approx(26.022132012144635)
 


### PR DESCRIPTION
This makes a configured currency bridge usable across all deflator vintages rather than only the one it was configured at, and adds the deflator data needed to reach recent years. Follow-up to #61; continues #25. The bridge-year interpretation follows @khaeru's proposal discussed in iiasa/sparccle-workflow#19.

`configure_currency(method, period)` previously redefined only the `{currency}_{period}` unit in terms of USD. Because each vintage is defined relative to its own anchor (`EUR_2005`, `USD_2005`), redefining a single non-anchor vintage detached it from the rest of the chain: `configure_currency("EXC", 2010)` could convert `USD_2010` → `EUR_2010` but raised `DimensionalityError` for `EUR_2024`. Only `period=2005` worked, because there the redefined unit is the anchor.

This PR reinterprets `period` as the exchange-rate bridge year only:

```
USD_y --(USD deflator)--> USD_period --(exchange rate @ period)--> EUR_period --(EUR deflator)--> EUR_z
```

- `configure_currency()` anchors the bridge at the target currency's chain anchor (`{currency}_2005`), scaled by the deflator factor between `period` and 2005, so the whole vintage chain stays connected. `period=2005` results are unchanged.
- A registry holds one bridge per target currency: re-running with the same `(method, period)` is a no-op; changing either raises `ValueError` rather than silently re-anchoring earlier conversions.
- Adds `USD_2023`, `USD_2024` and `EUR_2015` to `definitions.txt`.

To write that bridge, the EUR deflator factors are now named in `definitions.txt` : `_EUR_deflator_2010 = 0.901141`, with `EUR_2010 = _EUR_deflator_2010 * EUR_2005` as before, so `configure_currency()` can define the bridge as a plain pint expression, `EUR_2005 = USD_2010 / 0.754309 / _EUR_deflator_2010`, and let pint do the arithmetic. The factors follow the underscore prefix as `_gwp`, since they are not units. `DEVELOPING.rst` records that a new period or currency now needs a matching factor and chain anchor added by hand.

Data sourcing: the USD factors are each year's World Bank US GDP deflator (`NY.GDP.DEFL.ZS`, series last updated 2026-07-13) divided by the 2015 reference value and rounded to 4 decimals, following the existing 2000–2022 entries; `EUR_2015` uses the euro-area series (`NY.GDP.DEFL.KD.ZG`, aggregate `XC`), taken from the 2026-04-08 vintage.

Adds `test_currency_bridge` covering every supported `period` and every defined EUR vintage.